### PR TITLE
status2d-systray with multi-monitor

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -223,7 +223,7 @@ static void detachstack(Client *c);
 static Monitor *dirtomon(int dir);
 static void drawbar(Monitor *m);
 static void drawbars(void);
-static int drawstatusbar(Monitor *m, int bh, char* text);
+static int drawstatusbar(Monitor *m, int bh, int stw, char* text);
 static void enternotify(XEvent *e);
 static void expose(XEvent *e);
 static void focus(Client *c);
@@ -1015,7 +1015,7 @@ dirtomon(int dir)
 }
 
 int
-drawstatusbar(Monitor *m, int bh, char* stext) {
+drawstatusbar(Monitor *m, int bh, int stw, char* stext) {
 	int ret, i, w, x, len;
 	short isCode = 0;
 	char *text;
@@ -1047,7 +1047,7 @@ drawstatusbar(Monitor *m, int bh, char* stext) {
 		}
 	}
 	if (!isCode)
-		w += TEXTW(text) - lrpad + getsystraywidth();
+		w += TEXTW(text) - lrpad + stw;
 	else
 		isCode = 0;
 	text = p;
@@ -1136,7 +1136,7 @@ drawbar(Monitor *m)
 
 	/* draw status first so it can be overdrawn by tags later */
 	if (m == selmon) { /* status is only drawn on selected monitor */
-		sw = m->ww - drawstatusbar(m, bh, stext) - stw;
+		sw = m->ww - drawstatusbar(m, bh, stw, stext) - stw;
 	}
 
 	resizebarwin(m);


### PR DESCRIPTION
When using multi-monitor, and systray stick to one monitor.
There would be a empty space on statusbar when focusing on the monitor that without a systray.